### PR TITLE
Update Quansight Labs link

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -12,6 +12,6 @@ skills:
   - Open tech knowledge
 ---
 
-Hi I am Tania, I am the co-director at [Quansight Labs](https://www.quansight.com/labss). At my current role I am mainly focused on all things full-stack data science, scientific computing, and open source. As a co-director my priorities are driving Quansight Labs direction, vision and overall support and growth of the PyData ecosystem.
+Hi I am Tania, I am the co-director at [Quansight Labs](https://labs.quansight.org/). At my current role I am mainly focused on all things full-stack data science, scientific computing, and open source. As a co-director my priorities are driving Quansight Labs direction, vision and overall support and growth of the PyData ecosystem.
 
 I am particularly interested in the following topics:


### PR DESCRIPTION
👋 there was a typo, and after fixing the typo, a redirect to `https://labs.quansight.org/`.